### PR TITLE
Add last line of sheet. Fix parsing bug when last chord is empty

### DIFF
--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -97,6 +97,7 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
                 result.append(notes_vextab)
                 notes_vextab = ""
                 no_bars_from_start = 0
+    result.append(notes_vextab)
     return result
 
 
@@ -137,6 +138,9 @@ def generate_vextab_chords(chords, metrum_upper, metrum_lower):
                 result.append(chords_vextab)
                 chords_vextab = ".1"
                 no_bars_from_start = 0
+    while chords_vextab[-1] == ' ' and chords_vextab[-2] == ',':
+        chords_vextab = chords_vextab[0:chords_vextab[0:-2].rfind(' ,')+1]
+    result.append(chords_vextab)
     return result
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47048420/103174900-3819a180-4866-11eb-8eba-ae942697390f.png)

Simply adding the last line created a parsing bug when the chord sequence ended with ', ,'.
It should be fixed now.