### PR TITLE
Add and use post responses cache

### DIFF
--- a/view-app/src/file_dialog.js
+++ b/view-app/src/file_dialog.js
@@ -12,6 +12,7 @@ document.querySelector('#openDialog').addEventListener('click', function (event)
           if(recordedSoundClipContainer.lastChild) {
             recordedSoundClipContainer.removeChild(recordedSoundClipContainer.lastChild);
           }
+          clearCache();
           fetchAndDisplayGuitar(isShowingTransposed, isShowingNotes);
         }
       }).catch(err => {

--- a/view-app/src/js/Vex/notes.js
+++ b/view-app/src/js/Vex/notes.js
@@ -1,20 +1,43 @@
+let responseCached = "";
+let simplifiedResponseCached = "";
+
 function fetchAndDisplayGuitar(simplified, showNotes){
   if(simplified) {
-    var postPath = `http://127.0.0.1:5000/music_simple`;
+    if(simplifiedResponseCached === "") {
+      var postPath = `http://127.0.0.1:5000/music_simple`;
+      postJsonData(postPath, {input_file: filePath}).then((text) => {
+        simplifiedResponseCached = text;
+        drawEverything(simplifiedResponseCached, showNotes);
+      });
+    }
+    else {
+      drawEverything(simplifiedResponseCached, showNotes);
+    }
   }
   else {
-    var postPath = `http://127.0.0.1:5000/music`;
+    if(responseCached === "") {
+      var postPath = `http://127.0.0.1:5000/music`;
+      postJsonData(postPath, {input_file: filePath}).then((text) => {
+        responseCached = text;
+        drawEverything(responseCached, showNotes);
+      });
+    }
+    else {
+      drawEverything(responseCached, showNotes);
+    }
   }
-  postJsonData(postPath, {input_file: filePath}).then((data)=>{      
-      return data;
-  }).then((text)=>{
-    drawTabstaves(text, showNotes, true);
-    drawVexTabChordsCheatSheet(text);
-    unhideMusicInfoSections();
-    updateWithChordsSoundClipContainer();
-  }).catch(e=>{
-    console.log(e);
-  });
+}
+
+function drawEverything(vextabInput, showNotes) {
+  drawTabstaves(vextabInput, showNotes, true);
+  drawVexTabChordsCheatSheet(vextabInput);
+  unhideMusicInfoSections();
+  updateWithChordsSoundClipContainer();
+}
+
+function clearCache() {
+  responseCached = "";
+  simplifiedResponseCached = "";
 }
 
 function drawTabstaves(text, showNotes, showTablature) {

--- a/view-app/src/record.js
+++ b/view-app/src/record.js
@@ -34,6 +34,7 @@ function onstopMediaRecorder() {
     return data;
     }).then((text)=>{
       filePath = text.filename;
+      clearCache();
       fetchAndDisplayGuitar(isShowingTransposed, isShowingNotes);
   });
 }


### PR DESCRIPTION
Up to this point, we were sending a post request to the python server every time the musician clicked "transpose to easier key", "hide notes", "transpose to original key" or "show notes".
![image](https://user-images.githubusercontent.com/47048420/103482647-46c20480-4de2-11eb-8b44-d01c79aa640d.png)
![image](https://user-images.githubusercontent.com/47048420/103482650-4de91280-4de2-11eb-8236-684fb2c6874b.png)
Now, a post request is sent only when "transpose to easier key" is clicked for the first time or a new file is chosen/recorded.
I did this change in hopes that it will drastically reduce waiting time. Sadly, this didn't happen - it seems that I was wrong and the most time consuming part is not python server execution or saving to file, but rather drawing the sheet with vextab. So, this caching is not a huge improvement, but I think we could use it nonetheless.