### PR TITLE
Bugfix/preview file not reloading

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,9 +17,6 @@ def parse_args():
     parser.add_argument('--key', '-K',
                         help='Use correct key instead of detected',
                         type=str)
-    parser.add_argument('--wav',
-                        action="store_true",
-                        help='Save file as WAVE; works only on linux')
     args = parser.parse_args()
     return args
 

--- a/src/music_server.py
+++ b/src/music_server.py
@@ -241,7 +241,8 @@ def process_file(filename, force_key=None):
             app.config['TEMP_FOLDER'] / "output.midi",
             app.config['TEMP_FOLDER'] / "output.wav")
 
-    unique_preview_file = f"output{datetime.datetime.now().strftime('%m%d%H%M%S')}.ogg"
+    timestamp = datetime.datetime.now().strftime('%m%d%H%M%S')
+    unique_preview_file = f"output{timestamp}.ogg"
     prev_file = app.config['TEMP_FOLDER'] / unique_preview_file
     convert_wav_to_ogg(
         result_file,

--- a/src/music_server.py
+++ b/src/music_server.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 
+import datetime
 import pathlib
 import logging
 import shutil
@@ -195,7 +196,7 @@ def print_debug_info(sounds, chords):
             chords_i += 1
 
 
-def process_file(filename, force_key=None, output_wav=True):
+def process_file(filename, force_key=None):
     logger.debug(f"Procesing {filename}")
     sounds = sounds_generation.get_sounds_from_file(filename)
     # sounds = sounds_manipulation.change_key(sounds, 2)
@@ -219,31 +220,39 @@ def process_file(filename, force_key=None, output_wav=True):
     chords = chords_generation.get_chords_daria(sounds, key, (4, 8))
 
     duration_ms_of_32 = meter / 4
+
+    for x in app.config['TEMP_FOLDER'].iterdir():
+        if x.is_file():
+            file_str = str(x.name)
+            if len(file_str) >= 6 and file_str[0:6] == "output":
+                x.unlink()
+
     result_file = music_synthesis.create_midi(
         app.config['TEMP_FOLDER'] / "output.midi",
         sounds,
         chords,
         duration_ms_of_32)
-    if output_wav:
-        if os.name == 'nt':
-            result_file = music_synthesis.save_midifile_as_wav_windows(
-                app.config['TEMP_FOLDER'] / "output.midi",
-                app.config['TEMP_FOLDER'] / "output.wav")
-        else:
-            result_file = music_synthesis.save_midifile_as_wav_linux(
-                app.config['TEMP_FOLDER'] / "output.midi",
-                app.config['TEMP_FOLDER'] / "output.wav")
-        convert_wav_to_ogg(
-            app.config['TEMP_FOLDER'] / "output.wav",
-            app.config['TEMP_FOLDER'] / "output.ogg",
-        )
+    if os.name == 'nt':
+        result_file = music_synthesis.save_midifile_as_wav_windows(
+            app.config['TEMP_FOLDER'] / "output.midi",
+            app.config['TEMP_FOLDER'] / "output.wav")
+    else:
+        result_file = music_synthesis.save_midifile_as_wav_linux(
+            app.config['TEMP_FOLDER'] / "output.midi",
+            app.config['TEMP_FOLDER'] / "output.wav")
 
+    unique_preview_file = f"output{datetime.datetime.now().strftime('%m%d%H%M%S')}.ogg"
+    prev_file = app.config['TEMP_FOLDER'] / unique_preview_file
+    convert_wav_to_ogg(
+        result_file,
+        prev_file,
+    )
     logger.debug(f"Meter:\t\t{meter}")
     logger.debug(f"Key:\t\t{key}")
     print_debug_info(sounds, chords)
-    logger.debug(f"Result file:\t\t{result_file}")
+    logger.debug(f"Preview file:\t\t{prev_file}")
 
-    return sounds, chords, key, str(result_file)
+    return sounds, chords, key, str(prev_file.absolute())
 
 
 def convert_recorded_to_wav(source_file, destination_file):
@@ -260,4 +269,4 @@ def start_server(args):
     if args.http:
         app.run()
     else:
-        process_file(args.input, args.key, args.wav)
+        process_file(args.input, args.key)

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -138,7 +138,9 @@ def generate_vextab_chords(chords, metrum_upper, metrum_lower):
                 result.append(chords_vextab)
                 chords_vextab = ".1"
                 no_bars_from_start = 0
-    while len(chords_vextab) > 2 and chords_vextab[-1] == ' ' and chords_vextab[-2] == ',':
+    while (len(chords_vextab) > 2 and
+            chords_vextab[-1] == ' ' and
+            chords_vextab[-2] == ','):
         chords_vextab = chords_vextab[0:chords_vextab[0:-2].rfind(' ,')+1]
     if len(chords_vextab) > 2:
         result.append(chords_vextab)

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -138,9 +138,10 @@ def generate_vextab_chords(chords, metrum_upper, metrum_lower):
                 result.append(chords_vextab)
                 chords_vextab = ".1"
                 no_bars_from_start = 0
-    while chords_vextab[-1] == ' ' and chords_vextab[-2] == ',':
+    while len(chords_vextab) > 2 and chords_vextab[-1] == ' ' and chords_vextab[-2] == ',':
         chords_vextab = chords_vextab[0:chords_vextab[0:-2].rfind(' ,')+1]
-    result.append(chords_vextab)
+    if len(chords_vextab) > 2:
+        result.append(chords_vextab)
     return result
 
 

--- a/view-app/src/js/Vex/notes.js
+++ b/view-app/src/js/Vex/notes.js
@@ -11,7 +11,7 @@ function fetchAndDisplayGuitar(simplified, showNotes){
     drawTabstaves(text, showNotes, true);
     drawVexTabChordsCheatSheet(text);
     unhideMusicInfoSections();
-    updateWithChordsSoundClipContainer();
+    updateWithChordsSoundClipContainer(text.preview_file);
   }).catch(e=>{
     console.log(e);
   });
@@ -58,7 +58,7 @@ function drawVexTabChordsCheatSheet(text) {
   draw_chords(text.chord_types);
 }
 
-function updateWithChordsSoundClipContainer() {
+function updateWithChordsSoundClipContainer(audioURL) {
   if (withChordsSoundClipContainer.lastChild) {
     withChordsSoundClipContainer.removeChild(withChordsSoundClipContainer.lastChild);
   }
@@ -68,8 +68,8 @@ function updateWithChordsSoundClipContainer() {
   audio.setAttribute('controls', '');
   clipContainer.appendChild(audio);
   withChordsSoundClipContainer.appendChild(clipContainer);
-  const audioURL = "../../data/temp/output.ogg";
   audio.src = audioURL;
+  audio.load();
 }
 
 hideMusicInfoSections();


### PR DESCRIPTION
There was a problem with preview file (notes + chords played together) not reloading after changing a file.

It turned out that electron cached the old files and refused to update it. Afaiu there's no easy way to control caching and the easiest way to solve this is to change the name of the file every time it should be reloaded.

I also removed "wav" argument from main.py, bc it complicated the code and practically wasn't used now, as we have working wav on both windows and linux