### PR TITLE
Feature/preserve octave of sounds

### DIFF
--- a/src/music/base_sound.py
+++ b/src/music/base_sound.py
@@ -27,11 +27,15 @@ class BaseSound:
 
     @property
     def note(self):
-        return self._note
+        return self._note % 12 if self._note else self._note
+  
+    @property
+    def octave(self):
+        return self._note // 12 if self._note else self._note
 
     @note.setter
     def note(self, note):
-        self._note = note % 12 if note else note
+        self._note = note
 
     @property
     def duration(self):

--- a/src/music/base_sound.py
+++ b/src/music/base_sound.py
@@ -28,7 +28,7 @@ class BaseSound:
     @property
     def note(self):
         return self._note % 12 if self._note else self._note
-  
+
     @property
     def octave(self):
         return self._note // 12 if self._note else self._note

--- a/src/sounds_generation.py
+++ b/src/sounds_generation.py
@@ -11,13 +11,7 @@ def frequency_to_note(frequency):
     '''
     if frequency == 0:
         return None
-    return round(12*math.log2(frequency/440.0)+45) % 12
-
-
-def note_to_frequency(note):
-    if note is None:
-        return 0
-    return pow(2, (note-9.0)/12.0)*440.0
+    return round(12*math.log2(frequency/440.0)+45)
 
 
 def get_sounds_from_file(file):

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -30,13 +30,12 @@ STRINGS = {
 
 def sound_to_string(sound):
     # return f"{sound.symbol}/4"
-    sound.height = 3
     i = 6
-    while i > 1 and (STRINGS[i-1][1] < sound.height or
-                     (STRINGS[i-1][1] == sound.height and
+    while i > 1 and (STRINGS[i-1][1] < sound.octave or
+                     (STRINGS[i-1][1] == sound.octave and
                       STRINGS[i-1][0] < sound.note)):
         i -= 1
-    fret = (STRINGS[i][1] - sound.height)*12 + STRINGS[i][0] - sound.note
+    fret = (STRINGS[i][1] - sound.octave)*12 + STRINGS[i][0] - sound.note
     return f"{fret}/{i}"
 
 


### PR DESCRIPTION
I added "octave" getter in base_sound. Nothing should break because of that (base_sound.note results did not change). Now, when we have it, we probably want to use this octave info in chords generation.

Example ("Jedzie pociąg"):
Before
![image](https://user-images.githubusercontent.com/47048420/103485833-77f9ff00-4df9-11eb-8060-75b7cda145c6.png)

Now
![image](https://user-images.githubusercontent.com/47048420/103485800-45e89d00-4df9-11eb-86f7-acea83fa38bb.png)

(The 7th note in the second row is now ok)

