### PR TITLE
Divide chords and notes with bars

### DIFF
--- a/src/chords_simplification.py
+++ b/src/chords_simplification.py
@@ -60,6 +60,8 @@ def simplify(notes, chords, key):
     min_trans = max([-6, 16-min_note])
     # highest note that can be played on a guitar is E4, which is _note=40
     max_trans = min([6, 40-max_note])
+    if max_trans <= min_trans:
+        return notes, chords, key
 
     for i in range(min_trans, max_trans+1):
         score = 0

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -65,6 +65,28 @@ def decompose_chord(chord):
     return result
 
 
+def divide_chords_with_bars(chords, bar_duration):
+    result = []
+    duration_sum = 0
+    for chord in chords:
+        if duration_sum + chord.duration > bar_duration:
+            first_part = bar_duration - duration_sum
+            second_part = chord.duration - first_part
+            result.append(Chord(chord.note,
+                duration=first_part,
+                kind=chord.kind))
+            result.append(Chord(chord.note,
+                duration=second_part,
+                kind=chord.kind))
+            duration_sum = second_part
+        else:
+            result.append(chord)
+            duration_sum += chord.duration
+            if duration_sum == bar_duration:
+                duration_sum = 0
+    return result
+
+
 def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
     """Use information about the piece
     to create notes in an input format
@@ -136,7 +158,8 @@ def generate_vextab_chords(chords, metrum_upper, metrum_lower):
     bar_duration = metrum_upper*metrum_lower
     duration_from_start = 0
     no_bars_from_start = 0
-    cleared_chords = [dc for chord in chords for dc in decompose_chord(chord)]
+    divided_chords = divide_chords_with_bars(chords, bar_duration)
+    cleared_chords = [dc for chord in divided_chords for dc in decompose_chord(chord)]
     prev_chord = None
     chords_vextab += ".1"
 

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -30,13 +30,15 @@ STRINGS = {
 
 def sound_to_string(sound):
     # return f"{sound.symbol}/4"
+    if sound.symbol == 'r':
+        return "## "
     i = 6
     while i > 1 and (STRINGS[i-1][1] < sound.octave or
                      (STRINGS[i-1][1] == sound.octave and
                       STRINGS[i-1][0] < sound.note)):
         i -= 1
     fret = (STRINGS[i][1] - sound.octave)*12 + STRINGS[i][0] - sound.note
-    return f"{fret}/{i}"
+    return f"{-fret}/{i}"
 
 
 def chord_to_string(chord):
@@ -79,24 +81,45 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
     duration_from_start = 0
     no_bars_from_start = 0
     for sound in sounds:
-        if sound.symbol == "r":
-            notes_vextab += "## "
+        if duration_from_start + sound.duration > bar_duration:
+            first_part = bar_duration - duration_from_start
+            notes_vextab += ":"
+            notes_vextab += DURATION_TO_VEXTAB_DURATION[first_part]
+            notes_vextab += " "
+            notes_vextab += sound_to_string(sound)
+            notes_vextab += " "
+            notes_vextab += "| "
+            second_part = sound.duration - first_part
+            duration_from_start = second_part
+            no_bars_from_start += 1
+            if no_bars_from_start >= NO_BARS_IN_ROW:
+                result.append(notes_vextab)
+                notes_vextab = ""
+                no_bars_from_start = 0
+            notes_vextab += ":"
+            notes_vextab += DURATION_TO_VEXTAB_DURATION[first_part]
+            notes_vextab += " b"
+            notes_vextab += sound_to_string(sound)
+            notes_vextab += " "
         else:
             notes_vextab += ":"
             notes_vextab += DURATION_TO_VEXTAB_DURATION[sound.duration]
             notes_vextab += " "
             notes_vextab += sound_to_string(sound)
             notes_vextab += " "
-        duration_from_start += sound.duration
-        if duration_from_start >= bar_duration:
-            notes_vextab += "| "
-            duration_from_start -= bar_duration
-            no_bars_from_start += 1
-            if no_bars_from_start >= NO_BARS_IN_ROW:
-                result.append(notes_vextab)
-                notes_vextab = ""
-                no_bars_from_start = 0
+            duration_from_start += sound.duration
+            if duration_from_start == bar_duration:
+                notes_vextab += "| "
+                duration_from_start = 0
+                no_bars_from_start += 1
+                if no_bars_from_start >= NO_BARS_IN_ROW:
+                    result.append(notes_vextab)
+                    notes_vextab = ""
+                    no_bars_from_start = 0
+        
     result.append(notes_vextab)
+    for ehh in result:
+        print(ehh)
     return result
 
 

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -73,11 +73,11 @@ def divide_chords_with_bars(chords, bar_duration):
             first_part = bar_duration - duration_sum
             second_part = chord.duration - first_part
             result.append(Chord(chord.note,
-                duration=first_part,
-                kind=chord.kind))
+                                duration=first_part,
+                                kind=chord.kind))
             result.append(Chord(chord.note,
-                duration=second_part,
-                kind=chord.kind))
+                                duration=second_part,
+                                kind=chord.kind))
             duration_sum = second_part
         else:
             result.append(chord)
@@ -159,7 +159,8 @@ def generate_vextab_chords(chords, metrum_upper, metrum_lower):
     duration_from_start = 0
     no_bars_from_start = 0
     divided_chords = divide_chords_with_bars(chords, bar_duration)
-    cleared_chords = [dc for chord in divided_chords for dc in decompose_chord(chord)]
+    cleared_chords = [dc for chord in divided_chords
+                      for dc in decompose_chord(chord)]
     prev_chord = None
     chords_vextab += ".1"
 

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -37,7 +37,7 @@ def sound_to_string(sound):
                      (STRINGS[i-1][1] == sound.octave and
                       STRINGS[i-1][0] < sound.note)):
         i -= 1
-    fret = (STRINGS[i][1] - sound.octave)*12 + STRINGS[i][0] - sound.note
+    fret = sound.note - (STRINGS[i][1] - sound.octave)*12 - STRINGS[i][0]
     return f"{-fret}/{i}"
 
 
@@ -116,10 +116,8 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
                     result.append(notes_vextab)
                     notes_vextab = ""
                     no_bars_from_start = 0
-        
+
     result.append(notes_vextab)
-    for ehh in result:
-        print(ehh)
     return result
 
 

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -38,7 +38,7 @@ def sound_to_string(sound):
                       STRINGS[i-1][0] < sound.note)):
         i -= 1
     fret = sound.note - (STRINGS[i][1] - sound.octave)*12 - STRINGS[i][0]
-    return f"{-fret}/{i}"
+    return f"{fret}/{i}"
 
 
 def chord_to_string(chord):


### PR DESCRIPTION
Notes now can be divided by bars and are shown linked with a small curve. I also found a terrible bug - rests didn't have duration, so they inherited durations from the note on their left. It should be fixed now. Rhytmic values seem to be OK now and  sum up to 4/4 in every bar.
Edit: I also divided all chords with bars (this time without linking with anything, as there was no need). This fixed printing notes! "Sto lat" looks like this:
![image](https://user-images.githubusercontent.com/47048420/103926444-375ff580-5119-11eb-8b06-4620d0e8e21e.png)

