### PR TITLE
Round second parts of notes splitted with bars

### DIFF
--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -25,7 +25,7 @@ STRINGS = {
     2: (constants.REVERSE_SYMBOLS["B"], 3),
     1: (constants.REVERSE_SYMBOLS["E"], 4)
 }
-# print(STRINGS)
+
 
 def closest_legal_duration(duration):
     min_diff = duration

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -27,6 +27,16 @@ STRINGS = {
 }
 # print(STRINGS)
 
+def closest_legal_duration(duration):
+    min_diff = duration
+    best_key = None
+    for key in DURATION_TO_VEXTAB_DURATION.keys():
+        diff = abs(duration - key)
+        if diff < min_diff:
+            min_diff = diff
+            best_key = key
+    return best_key
+
 
 def sound_to_string(sound):
     # return f"{sound.symbol}/4"
@@ -112,6 +122,8 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
             notes_vextab += " "
             notes_vextab += "| "
             second_part = sound.duration - first_part
+            # second part can become not legal (ei. 32 - 12 = 20)
+            second_part = closest_legal_duration(second_part)
             duration_from_start = second_part
             no_bars_from_start += 1
             if no_bars_from_start >= NO_BARS_IN_ROW:
@@ -119,7 +131,7 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
                 notes_vextab = ""
                 no_bars_from_start = 0
             notes_vextab += ":"
-            notes_vextab += DURATION_TO_VEXTAB_DURATION[first_part]
+            notes_vextab += DURATION_TO_VEXTAB_DURATION[second_part]
             notes_vextab += " "
             if sound.symbol != 'r':
                 notes_vextab += 'b'

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -115,6 +115,7 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
     for sound in sounds:
         if duration_from_start + sound.duration > bar_duration:
             first_part = bar_duration - duration_from_start
+            first_part = closest_legal_duration(first_part)
             notes_vextab += ":"
             notes_vextab += DURATION_TO_VEXTAB_DURATION[first_part]
             notes_vextab += " "
@@ -122,7 +123,6 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
             notes_vextab += " "
             notes_vextab += "| "
             second_part = sound.duration - first_part
-            # second part can become not legal (ei. 32 - 12 = 20)
             second_part = closest_legal_duration(second_part)
             duration_from_start = second_part
             no_bars_from_start += 1


### PR DESCRIPTION
There was a bug when splitting note with a bar - duration of the second part was always the same as duration of the first part. When I fixed this, two potential problems appeared:
1. After filling the first tab with some part of the note, we can be left with an illegal measure for the second bar. For example, consider adding a whole note here:
![image](https://user-images.githubusercontent.com/47048420/104051089-dbb06d80-51e7-11eb-99b2-b12d2aacc7c7.png)
We would have to use a dotted 4th note
![image](https://user-images.githubusercontent.com/47048420/104051170-ff73b380-51e7-11eb-84c5-f2907744566d.png)
and then, we would be left with an illegal value (4th note + dotted 4th note) for the second tab. Right now, I solved this just by rounding the second part to the nearest legal value.
![image](https://user-images.githubusercontent.com/47048420/104051370-51b4d480-51e8-11eb-97a8-d23553d42f6f.png)
This is not ideal, but I have no idea how to write (4th note + dotted 4th note) as one note.

2. Sometimes, the first tab can only be filled with an illegal value. I ignore this and fill it with the closest legal value. This is an error in musical notation and can lead to bad printing of notes. However, I did not find such error in any of the files from /perfect/.