### PR TITLE
Feature/better sounds recognition

### DIFF
--- a/src/meter_recognition/fit_to_bar.py
+++ b/src/meter_recognition/fit_to_bar.py
@@ -15,7 +15,7 @@ def beat_id_closest_to_timestamp(beats, timestamp):
 def simple_sound_beat_dur(beats, sound):
     id = sound.beat_id
 
-    if id==len(beats)-1:
+    if id == len(beats)-1:
         b2 = beats[id]
         b1 = beats[id-1]
     else:

--- a/src/meter_recognition/fit_to_bar.py
+++ b/src/meter_recognition/fit_to_bar.py
@@ -14,8 +14,13 @@ def beat_id_closest_to_timestamp(beats, timestamp):
 
 def simple_sound_beat_dur(beats, sound):
     id = sound.beat_id
-    b1 = beats[id]
-    b2 = beats[id+1]
+
+    if id==len(beats)-1:
+        b2 = beats[id]
+        b1 = beats[id-1]
+    else:
+        b1 = beats[id]
+        b2 = beats[id+1]
     local_duration_of_16s = (b2-b1)/4
     no_16s_in_sound = round(sound.duration_ms/local_duration_of_16s)
 

--- a/src/sounds_generation.py
+++ b/src/sounds_generation.py
@@ -39,14 +39,14 @@ def get_sounds_from_file(file):
     return get_sounds_from_list(xs, strength_changes, notes)
 
 
-def get_sounds_from_list(timestamps, amplitude_changes, notes):
+def get_sounds_from_list(timestamps, stength_changes, notes):
     # for each timeframe recognise note and
     # merge same more notes together
     sounds = []
     last_note = None
     last_note_timestamp = 0.0
     for note, timestamp, a_changes \
-            in zip(notes, timestamps, amplitude_changes):
+            in zip(notes, timestamps, stength_changes):
         if (last_note != note) or a_changes:
             sounds.append(music.Sound(last_note, last_note_timestamp,
                                       timestamp-last_note_timestamp))

--- a/src/sounds_generation.py
+++ b/src/sounds_generation.py
@@ -29,9 +29,11 @@ def get_sounds_from_file(file):
     snd = parselmouth.Sound(str(file))
     pitch = snd.to_pitch()
     frequencies = pitch.selected_array['frequency']
-    strengths = pitch.selected_array['strength']
+    stgt = pitch.selected_array['strength']
     xs = pitch.xs()
-    strength_changes = [(strengths[i]-strengths[i-1]>(xs[i]-xs[i-1])*STRENGTH_CHANGE_TO_SEPARATE) for i in range(1,len(strengths))]
+    strength_changes = \
+        [(stgt[i]-stgt[i-1] > (xs[i]-xs[i-1])*STRENGTH_CHANGE_TO_SEPARATE)
+         for i in range(1, len(stgt))]
     strength_changes.insert(0, False)
     notes = [frequency_to_note(freq) for freq in frequencies]
     return get_sounds_from_list(xs, strength_changes, notes)
@@ -43,7 +45,8 @@ def get_sounds_from_list(timestamps, amplitude_changes, notes):
     sounds = []
     last_note = None
     last_note_timestamp = 0.0
-    for note, timestamp, a_changes in zip(notes, timestamps, amplitude_changes):
+    for note, timestamp, a_changes \
+            in zip(notes, timestamps, amplitude_changes):
         if (last_note != note) or a_changes:
             sounds.append(music.Sound(last_note, last_note_timestamp,
                                       timestamp-last_note_timestamp))

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -25,7 +25,7 @@ STRINGS = {
     2: (constants.REVERSE_SYMBOLS["B"], 3),
     1: (constants.REVERSE_SYMBOLS["E"], 4)
 }
-# print(STRINGS)
+
 
 def closest_legal_duration(duration):
     min_diff = duration

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -27,6 +27,16 @@ STRINGS = {
 }
 # print(STRINGS)
 
+def closest_legal_duration(duration):
+    min_diff = duration
+    best_key = None
+    for key in DURATION_TO_VEXTAB_DURATION.keys():
+        diff = abs(duration - key)
+        if diff < min_diff:
+            min_diff = diff
+            best_key = key
+    return best_key
+
 
 def sound_to_string(sound):
     # return f"{sound.symbol}/4"
@@ -112,6 +122,8 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
             notes_vextab += " "
             notes_vextab += "| "
             second_part = sound.duration - first_part
+            # second part can become not legal (ei. 32 - 12 = 20)
+            second_part = closest_legal_duration(second_part)
             duration_from_start = second_part
             no_bars_from_start += 1
             if no_bars_from_start >= NO_BARS_IN_ROW:
@@ -119,7 +131,7 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
                 notes_vextab = ""
                 no_bars_from_start = 0
             notes_vextab += ":"
-            notes_vextab += DURATION_TO_VEXTAB_DURATION[first_part]
+            notes_vextab += DURATION_TO_VEXTAB_DURATION[second_part]
             notes_vextab += " "
             if sound.symbol != 'r':
                 notes_vextab += 'b'

--- a/src/vextab_parsing.py
+++ b/src/vextab_parsing.py
@@ -115,6 +115,7 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
     for sound in sounds:
         if duration_from_start + sound.duration > bar_duration:
             first_part = bar_duration - duration_from_start
+            first_part = closest_legal_duration(first_part)
             notes_vextab += ":"
             notes_vextab += DURATION_TO_VEXTAB_DURATION[first_part]
             notes_vextab += " "
@@ -122,7 +123,6 @@ def generate_vextab_notes(sounds, metrum_upper, metrum_lower):
             notes_vextab += " "
             notes_vextab += "| "
             second_part = sound.duration - first_part
-            # second part can become not legal (ei. 32 - 12 = 20)
             second_part = closest_legal_duration(second_part)
             duration_from_start = second_part
             no_bars_from_start += 1


### PR DESCRIPTION
Very bad results that we were obraining from perfect test cases were mainly because the sound generation couldn't manage the same consecutive notes and helplessly merged them into one long note.
![image](https://user-images.githubusercontent.com/47048420/104075560-69ee1900-5213-11eb-9cf6-ed671a2c0110.png)
I used 'strength' parameter from parselmouth's Pitch, meaning (I guess) level of certainty that the pitch prediction was accurate. I check for places where strength suddenly raises and mark them to be the moments when a new note was played. Then, I check for this moments when joining consecutive predictions into notes. This change improves sound recognition results - tests show raise in accuracy from 0,59 to 0,88 in perfect/ and from 0,72 to 0,78 in other_rec/.
These results can be accidental (also bc I chose STRENGTH_CHANGE_TO_SEPARATE value which simply gave the best results), but who cares anyway.