### PR TITLE
Handle invalid input, add better loading

### DIFF
--- a/src/music_server.py
+++ b/src/music_server.py
@@ -46,7 +46,7 @@ def frontend_communication_upload_recorded():
         logger.error(f"Bad request: {request}\n Exception: {e}")
         return jsonify({
             "error": "Expected file named recordingTemp"
-        })
+        }), 400
     filename_ogg = app.config['TEMP_FOLDER'] / "recordingTemp.ogg"
     file.save(filename_ogg)
     filename = app.config['TEMP_FOLDER'] / "recordingTemp.wav"
@@ -67,7 +67,7 @@ def frontend_communication_save_with_chords():
         logger.error(f"Bad request: {request}\n Exception: {e}")
         return jsonify({
             "error": "Expected json with output_file key"
-        })
+        }), 400
     filename_src = app.config['TEMP_FOLDER'] / "output.wav"
     shutil.copyfile(filename_src, filename_dest)
     return jsonify({})
@@ -86,7 +86,7 @@ def frontend_communication_save_recorded():
         logger.error(f"Bad request: {request}\n Exception: {e}")
         return jsonify({
             "error": "Expected json with output_file key"
-        })
+        }), 400
     print(filename_dest)
     filename_src = app.config['TEMP_FOLDER'] / "recordingTemp.wav"
     print(filename_src)
@@ -125,14 +125,20 @@ def frontend_communication():
         logger.error(f"Bad request: {request}\n Exception: {e}")
         return jsonify({
             "error": "Expected json with input_file key"
-        })
+        }), 400
     filename = pathlib.Path(filename)
     if not filename.is_file():
         logger.error(f"File {filename} does not exist.")
         return jsonify({
             "error": f"File {filename} does not exist."
-        })
-    notes, chords, key, preview_file = process_file(filename, False)
+        }), 400
+    try:
+        notes, chords, key, preview_file = process_file(filename, False)
+    except Exception as e:
+        logger.error(f"Bad request: {request}\n Exception: {e}")
+        return jsonify({
+            "error": "File did not contain a valid melody"
+        }), 400
     return jsonify(render_result(notes, chords, key, preview_file, 4, 8))
 
 
@@ -146,14 +152,21 @@ def frontend_communication_simple():
         logger.error(f"Bad request: {request}\n Exception: {e}")
         return jsonify({
             "error": "Expected json with input_file key"
-        })
+        }), 400
     filename = pathlib.Path(filename)
     if not filename.is_file():
         logger.error(f"File {filename} does not exist.")
         return jsonify({
             "error": f"File {filename} does not exist."
-        })
-    notes, chords, key, preview_file = process_file(filename, True)
+        }), 400
+    
+    try:
+        notes, chords, key, preview_file = process_file(filename, True)
+    except Exception as e:
+        logger.error(f"Bad request: {request}\n Exception: {e}")
+        return jsonify({
+            "error": "File did not contain a valid melody"
+        }), 400
     return jsonify(render_result(notes, chords, key, preview_file, 4, 8))
 
 

--- a/src/music_server.py
+++ b/src/music_server.py
@@ -159,7 +159,7 @@ def frontend_communication_simple():
         return jsonify({
             "error": f"File {filename} does not exist."
         }), 400
-    
+
     try:
         notes, chords, key, preview_file = process_file(filename, True)
     except Exception as e:

--- a/view-app/src/css/templatemo-breezed.css
+++ b/view-app/src/css/templatemo-breezed.css
@@ -824,6 +824,21 @@ banner
   max-width: none;
 }
 
+.loader {
+  border: 8px solid #ffffff;
+  border-top: 8px solid  #252525;
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  animation: spin 1s linear infinite;
+  margin: 0 auto;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
 *,
 *:before,
 *:after {
@@ -1077,6 +1092,16 @@ ul.slick-dots {
   margin: 50px 0px 0px 0px;
   position: relative;
   z-index: 9;
+}
+/*loading_section*/
+#loading_section{  
+  padding: 50px 0px 0px 0px;
+  position: relative;
+  z-index: 9;
+}
+#file_section .container
+{
+  align-content: center;
 }
 /* chords_section
 */

--- a/view-app/src/file_dialog.js
+++ b/view-app/src/file_dialog.js
@@ -12,6 +12,9 @@ document.querySelector('#openDialog').addEventListener('click', function (event)
           if(recordedSoundClipContainer.lastChild) {
             recordedSoundClipContainer.removeChild(recordedSoundClipContainer.lastChild);
           }
+          isShowingTransposed = false;
+          transposeButton.textContent = "Transpose to easier key";
+          transposeButton.className = "main-stroked-button";
           clearCache();
           fetchAndDisplayGuitar(isShowingTransposed, isShowingNotes);
         }

--- a/view-app/src/index.html
+++ b/view-app/src/index.html
@@ -119,7 +119,7 @@ https://templatemo.com/tm-543-breezed
             </div>
         </div>
      </section>
-     
+
     <section class="section" id="choose_section">
     <div class="main-banner header-text" id="top">
         <div class="Modern-Slider">
@@ -153,6 +153,12 @@ https://templatemo.com/tm-543-breezed
     </section>
     
     
+     
+    <section class="section" id="loading_section">
+        <div class="container">
+            <div class="loader"></div>
+        </div>
+     </section>
 
     <!-- ***** Main Banner Area End ***** -->
     <!--- ***** Notes Area Starts *****-->

--- a/view-app/src/js/Vex/notes.js
+++ b/view-app/src/js/Vex/notes.js
@@ -4,10 +4,21 @@ let simplifiedResponseCached = "";
 function fetchAndDisplayGuitar(simplified, showNotes){
   if(simplified) {
     if(simplifiedResponseCached === "") {
+      hideMusicInfoSections();
       var postPath = `http://127.0.0.1:5000/music_simple`;
-      postJsonData(postPath, {input_file: filePath}).then((text) => {
+      postJsonData(postPath, {input_file: filePath}).then((response) => {
+        if (!response.ok) {
+          throw new Error('Error in post simplified');
+        }
+        else {
+          return response.json();
+        }
+      }).then((text) => {
+        unhideMusicInfoSections();
         simplifiedResponseCached = text;
         drawEverything(simplifiedResponseCached, showNotes);
+      }).catch(error => {
+        //display some error message
       });
     }
     else {
@@ -16,10 +27,21 @@ function fetchAndDisplayGuitar(simplified, showNotes){
   }
   else {
     if(responseCached === "") {
+      hideMusicInfoSections();
       var postPath = `http://127.0.0.1:5000/music`;
-      postJsonData(postPath, {input_file: filePath}).then((text) => {
-        responseCached = text;
-        drawEverything(responseCached, showNotes);
+      postJsonData(postPath, {input_file: filePath}).then((response) => {
+        if (!response.ok) {
+          throw new Error('Error in post');
+        }
+        else {
+          return response.json();
+        }
+      }).then((text) => {
+          unhideMusicInfoSections();
+          responseCached = text;
+          drawEverything(responseCached, showNotes);
+        }).catch(error => {
+          //display some error message
       });
     }
     else {

--- a/view-app/src/js/Vex/notes.js
+++ b/view-app/src/js/Vex/notes.js
@@ -3,8 +3,8 @@ let simplifiedResponseCached = "";
 
 function fetchAndDisplayGuitar(simplified, showNotes){
   if(simplified) {
+    hideMusicInfoSections();
     if(simplifiedResponseCached === "") {
-      hideMusicInfoSections();
       var postPath = `http://127.0.0.1:5000/music_simple`;
       postJsonData(postPath, {input_file: filePath}).then((response) => {
         if (!response.ok) {
@@ -14,20 +14,22 @@ function fetchAndDisplayGuitar(simplified, showNotes){
           return response.json();
         }
       }).then((text) => {
-        unhideMusicInfoSections();
         simplifiedResponseCached = text;
         drawEverything(simplifiedResponseCached, showNotes);
+        unhideMusicInfoSections();
       }).catch(error => {
-        //display some error message
+        //display some error message (transposition failed or sth)
       });
     }
     else {
       drawEverything(simplifiedResponseCached, showNotes);
+      unhideMusicInfoSections();
     }
   }
   else {
+    hideMusicInfoSections();
     if(responseCached === "") {
-      hideMusicInfoSections();
+      hideChoosePanel();
       var postPath = `http://127.0.0.1:5000/music`;
       postJsonData(postPath, {input_file: filePath}).then((response) => {
         if (!response.ok) {
@@ -37,15 +39,17 @@ function fetchAndDisplayGuitar(simplified, showNotes){
           return response.json();
         }
       }).then((text) => {
-          unhideMusicInfoSections();
-          responseCached = text;
-          drawEverything(responseCached, showNotes);
-        }).catch(error => {
-          //display some error message
-      });
+        responseCached = text;
+        drawEverything(responseCached, showNotes);
+        unhideChoosePanel();
+        unhideMusicInfoSections();
+      }).catch(error => {
+        //display some error message
+    });
     }
     else {
       drawEverything(responseCached, showNotes);
+      unhideMusicInfoSections();
     }
   }
 }
@@ -53,7 +57,6 @@ function fetchAndDisplayGuitar(simplified, showNotes){
 function drawEverything(vextabInput, showNotes) {
   drawTabstaves(vextabInput, showNotes, true);
   drawVexTabChordsCheatSheet(vextabInput);
-  unhideMusicInfoSections();
   updateWithChordsSoundClipContainer(vextabInput.preview_file);
 }
 
@@ -87,19 +90,25 @@ function drawTabstaves(text, showNotes, showTablature) {
     artist.render(renderer);
 }
 
-function unhideMusicInfoSections() {
+function unhideChoosePanel() {
   document.getElementById('choose_section').style.height = chooseSectionHeight;
   document.getElementById('choose_section').style.overflowY = "auto";
+}
+
+function hideChoosePanel() {
+  if(document.getElementById('choose_section').style.height != "0px") {
+    chooseSectionHeight = document.getElementById('choose_section').style.height;
+    document.getElementById('choose_section').style.height = "0px";
+  }
+}
+
+function unhideMusicInfoSections() {
   document.getElementById('music_section').style.display = "block";
   document.getElementById('chords_section').style.display = "block";
   document.getElementById('arrow_button').style.display = "block";
 }
 
 function hideMusicInfoSections() {
-  if(document.getElementById('choose_section').style.height != "0px") {
-    chooseSectionHeight = document.getElementById('choose_section').style.height;
-    document.getElementById('choose_section').style.height = "0px";
-  }
   document.getElementById('choose_section').style.overflowY = "hidden"; 
   document.getElementById('music_section').style.display = "none";
   document.getElementById('chords_section').style.display = "none";
@@ -124,6 +133,7 @@ function updateWithChordsSoundClipContainer(audioURL) {
   audio.load();
 }
 
+hideChoosePanel();
 hideMusicInfoSections();
 
 const VF = vextab.Vex.Flow

--- a/view-app/src/js/Vex/notes.js
+++ b/view-app/src/js/Vex/notes.js
@@ -96,8 +96,10 @@ function unhideMusicInfoSections() {
 }
 
 function hideMusicInfoSections() {
-  chooseSectionHeight = document.getElementById('choose_section').style.height;
-  document.getElementById('choose_section').style.height = "0px";
+  if(document.getElementById('choose_section').style.height != "0px") {
+    chooseSectionHeight = document.getElementById('choose_section').style.height;
+    document.getElementById('choose_section').style.height = "0px";
+  }
   document.getElementById('choose_section').style.overflowY = "hidden"; 
   document.getElementById('music_section').style.display = "none";
   document.getElementById('chords_section').style.display = "none";

--- a/view-app/src/js/Vex/notes.js
+++ b/view-app/src/js/Vex/notes.js
@@ -4,6 +4,7 @@ let simplifiedResponseCached = "";
 function fetchAndDisplayGuitar(simplified, showNotes){
   if(simplified) {
     hideMusicInfoSections();
+    unhideLoadingSection();
     if(simplifiedResponseCached === "") {
       var postPath = `http://127.0.0.1:5000/music_simple`;
       postJsonData(postPath, {input_file: filePath}).then((response) => {
@@ -16,18 +17,22 @@ function fetchAndDisplayGuitar(simplified, showNotes){
       }).then((text) => {
         simplifiedResponseCached = text;
         drawEverything(simplifiedResponseCached, showNotes);
+        hideLoadingSection();
         unhideMusicInfoSections();
       }).catch(error => {
+        hideLoadingSection();
         //display some error message (transposition failed or sth)
       });
     }
     else {
       drawEverything(simplifiedResponseCached, showNotes);
+      hideLoadingSection();
       unhideMusicInfoSections();
     }
   }
   else {
     hideMusicInfoSections();
+    unhideLoadingSection();
     if(responseCached === "") {
       hideChoosePanel();
       var postPath = `http://127.0.0.1:5000/music`;
@@ -43,13 +48,16 @@ function fetchAndDisplayGuitar(simplified, showNotes){
         drawEverything(responseCached, showNotes);
         unhideChoosePanel();
         unhideMusicInfoSections();
+        hideLoadingSection();
       }).catch(error => {
+        hideLoadingSection();
         //display some error message
     });
     }
     else {
       drawEverything(responseCached, showNotes);
       unhideMusicInfoSections();
+      hideLoadingSection();
     }
   }
 }

--- a/view-app/src/post_requests.js
+++ b/view-app/src/post_requests.js
@@ -6,7 +6,7 @@ async function postJsonData(url = '', data = {}) {
     },
     body: JSON.stringify(data)
   });
-  return response.json();
+  return response;
 }
 
 async function postFormData(url = '', data = {}) {

--- a/view-app/src/record.js
+++ b/view-app/src/record.js
@@ -35,6 +35,9 @@ function onstopMediaRecorder() {
     }).then((text)=>{
       filePath = text.filename;
       clearCache();
+      isShowingTransposed = false;
+      transposeButton.textContent = "Transpose to easier key";
+      transposeButton.className = "main-stroked-button";
       fetchAndDisplayGuitar(isShowingTransposed, isShowingNotes);
   });
 }

--- a/view-app/src/render.js
+++ b/view-app/src/render.js
@@ -12,6 +12,14 @@ isShowingTransposed = false
 isShowingNotes = true
 isRecording = false
 
+function unhideLoadingSection() {
+  document.getElementById('loading_section').style.display = "block";
+}
+
+function hideLoadingSection() {
+  document.getElementById('loading_section').style.display = "none";
+}
+
 function onclickTransposeButton(){
   if(isShowingTransposed) {
     transposeButton.textContent = "Transpose to easier key";
@@ -75,3 +83,4 @@ saveRecordedButton.addEventListener('click', () => {
   onclickSavRecordedButton();
 });
 
+hideLoadingSection();


### PR DESCRIPTION
1. Invalid input handling

I added a big "try" around file processing on server side, if there is any exception it responds with 400 code. Frontend awaits this response and if the code is 400 it doesn't try to render notes.
So, this is the view when the user requested analysing some invalid file (not wav, not existing, too short)
![image](https://user-images.githubusercontent.com/47048420/104232503-b96d5880-5450-11eb-9e16-e7cad3ceb883.png)


It would be great to add some message here, I can do it next if we think we can manage to deliver the documentation on time.

Unfortunately, Electron logs an error after post with response other than 200.
![image](https://user-images.githubusercontent.com/47048420/104232541-c9853800-5450-11eb-8a5f-f5867b9ddeaa.png)

I don't know how to prevent this, but I don't think this is something bad, it won't be visible for the user anyway.

2. Better loading

Now, every time a new file is loaded, choose section and music sections become invisible, and a section with a loading animation pops up.
![image](https://user-images.githubusercontent.com/47048420/104232585-d9048100-5450-11eb-9b68-45abfd57e8f5.png)

I a similar way, when "transpose to easier key" is clicked for the first time (i.e. it's not fetched), a loading section appears, but this time under the choose section.
![image](https://user-images.githubusercontent.com/47048420/104232819-297bde80-5451-11eb-9557-d5f231fe7599.png)

Every newly loaded file now starts not transposed (up to this point it was inherited from the previous file which makes no sense).