### PR TITLE
Always transpose. When tie choose smaller transposition.

### DIFF
--- a/src/chords_simplification.py
+++ b/src/chords_simplification.py
@@ -74,7 +74,8 @@ def simplify(notes, chords, key):
                 score += CHORDS_SCORING_MAJOR[(c.note + i) % 12]
             elif 'minor' in c.kind:
                 score += CHORDS_SCORING_MINOR[(c.note + i) % 12]
-        if score < min_score or (score == min_score and abs(i)<abs(min_trans)):
+        if score < min_score or \
+                (score == min_score and abs(i) < abs(min_trans)):
             min_score = score
             min_trans = i
     key.note = (key.note + min_trans) % 12

--- a/src/chords_simplification.py
+++ b/src/chords_simplification.py
@@ -63,14 +63,18 @@ def simplify(notes, chords, key):
     if max_trans <= min_trans:
         return notes, chords, key
 
-    for i in range(min_trans, max_trans+1):
+    trans_range = list(range(min_trans, max_trans+1))
+    if 0 in trans_range:
+        trans_range.remove(0)
+
+    for i in trans_range:
         score = 0
         for c in chords:
             if 'major' in c.kind:
                 score += CHORDS_SCORING_MAJOR[(c.note + i) % 12]
             elif 'minor' in c.kind:
                 score += CHORDS_SCORING_MINOR[(c.note + i) % 12]
-        if score < min_score:
+        if score < min_score or (score == min_score and abs(i)<abs(min_trans)):
             min_score = score
             min_trans = i
     key.note = (key.note + min_trans) % 12


### PR DESCRIPTION
So we won't have to print "This key is already the easiest key".
Also, if I were using the app, I would probably want it to transpose anyway, so I could look which key is easier for me. The criterias of chords being "easy" are fuzzy, so I think we can do that.